### PR TITLE
adding alternatives names to meta data requirements

### DIFF
--- a/prompt-shared-state/package.json
+++ b/prompt-shared-state/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tumaet/prompt-shared-state",
-    "version": "0.0.10",
+    "version": "0.0.11",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/ls1intum/prompt-lib.git"

--- a/prompt-shared-state/src/interfaces/coursePhaseType/coursePhaseTypeMetaDataItem.ts
+++ b/prompt-shared-state/src/interfaces/coursePhaseType/coursePhaseTypeMetaDataItem.ts
@@ -1,4 +1,5 @@
 export type CoursePhaseTypeMetaDataItem = {
   name: string
   type: string
+  alternativeNames?: string[]
 }


### PR DESCRIPTION
This pull request includes updates to the `prompt-shared-state` package, specifically a version bump and an enhancement to the `CoursePhaseTypeMetaDataItem` type.

Version update:

* [`prompt-shared-state/package.json`](diffhunk://#diff-9b995d8e0dcc8311347220c81529c9c866d22f55f453cab55fb0cbde96331cf6L3-R3): Updated package version from `0.0.10` to `0.0.11`.

Enhancement to type definitions:

* [`prompt-shared-state/src/interfaces/coursePhaseType/coursePhaseTypeMetaDataItem.ts`](diffhunk://#diff-6d4c3b668468248c0ae935f6a7b0e170ab168d99a1f09d4d1d7593c15a72c0b2R4): Added an optional `alternativeNames` property to the `CoursePhaseTypeMetaDataItem` type.