### PR TITLE
adjusted the update course functionality

### DIFF
--- a/prompt-shared-state/package.json
+++ b/prompt-shared-state/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@tumaet/prompt-shared-state",
-    "version": "0.0.13",
+    "version": "0.0.15",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/ls1intum/prompt-lib.git"

--- a/prompt-shared-state/src/interfaces/course/updateCourse.ts
+++ b/prompt-shared-state/src/interfaces/course/updateCourse.ts
@@ -1,4 +1,8 @@
 export interface UpdateCourseData {
+  startDate?: Date
+  endDate?: Date
+  courseType?: string
+  ects?: number
   restrictedData?: { [key: string]: any }
   studentReadableData?: { [key: string]: any }
 }

--- a/prompt-shared-state/src/zustand/useCourseStore.tsx
+++ b/prompt-shared-state/src/zustand/useCourseStore.tsx
@@ -2,13 +2,14 @@ import { create } from 'zustand'
 import { Course } from '../interfaces/course/course'
 
 interface CourseStoreState {
-  selectedCourse?: Course
   courses: Course[]
   ownCourseIDs: string[]
 }
 
 interface CourseStoreAction {
-  setSelectedCourse: (selectedCourse?: Course) => void
+  setSelectedCourseID: (selectedCourseID: string) => void
+  getSelectedCourseID: () => string | null
+  removeSelectedCourseID: () => void
   setCourses: (courses: Course[]) => void
   setOwnCourseIDs: (ownCourseIDs: string[]) => void
   isStudentOfCourse: (courseID: string) => boolean
@@ -17,14 +18,14 @@ interface CourseStoreAction {
 export const useCourseStore = create<CourseStoreState & CourseStoreAction>((set) => ({
   courses: [],
   ownCourseIDs: [],
-  setSelectedCourse: (selectedCourse?: Course) => {
-    if (selectedCourse) {
-      localStorage.setItem('selected-course', selectedCourse.id)
-    } else {
-      localStorage.removeItem('selected-course')
-    }
-
-    set({ selectedCourse })
+  getSelectedCourseID: () => {
+    return localStorage.getItem('selected-course')
+  },
+  setSelectedCourseID: (selectedCourseID: string) => {
+    localStorage.setItem('selected-course', selectedCourseID)
+  },
+  removeSelectedCourseID: () => {
+    localStorage.removeItem('selected-course')
   },
   setCourses: (courses: Course[]) => set({ courses }),
   setOwnCourseIDs: (ownCourseIDs: string[]) => set({ ownCourseIDs }),


### PR DESCRIPTION
This pull request includes several changes to the `prompt-shared-state` package, focusing on enhancing the course update interface and modifying the course store state management. The most important changes include updating the package version, extending the `UpdateCourseData` interface, and refactoring the course store state management to use course IDs instead of course objects.

### Version Update:
* [`prompt-shared-state/package.json`](diffhunk://#diff-9b995d8e0dcc8311347220c81529c9c866d22f55f453cab55fb0cbde96331cf6L3-R3): Updated the package version from `0.0.13` to `0.0.15`.

### Interface Enhancements:
* [`prompt-shared-state/src/interfaces/course/updateCourse.ts`](diffhunk://#diff-489125f6e67597149f0abcd277c4ea06e36a8c366b9579361711f22de0496746R2-R5): Added optional fields `startDate`, `endDate`, `courseType`, and `ects` to the `UpdateCourseData` interface.

### State Management Refactor:
* `prompt-shared-state/src/zustand/useCourseStore.tsx`: 
  * Replaced `setSelectedCourse` with methods to manage selected course IDs (`setSelectedCourseID`, `getSelectedCourseID`, and `removeSelectedCourseID`).
  * Updated the store initialization to reflect the changes in selected course management.