### PR TITLE
Fix global layout issue with main container having too much width configured

### DIFF
--- a/prompt-ui-components/src/components/ui/sidebar.tsx
+++ b/prompt-ui-components/src/components/ui/sidebar.tsx
@@ -310,7 +310,7 @@ const SidebarInset = React.forwardRef<HTMLDivElement, React.ComponentProps<'main
       <main
         ref={ref}
         className={cn(
-          'relative flex min-h-svh flex-1 flex-col bg-background',
+          'relative flex min-h-svh flex-1 flex-col bg-background min-w-0 w-auto',
           'peer-data-[variant=inset]:min-h-[calc(100svh-theme(spacing.4))] md:peer-data-[variant=inset]:m-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow',
           className,
         )}


### PR DESCRIPTION
**what changed:**
add tailwind classes "min-w-0" and "w-auto" to allow the flex-row component SidebarInset to shrink and therefore not overflow the entire content


**why:**
The main layout in probt is defined by the Sidebar component, which uses a horizontal flex layout (flex-row). There's a sidebar and a SidebarInsert component. The SidebarInset component holds the main content area next to the sidebar. → the problematic component. 
SidebarInset's the default flex behaviour is to not go below the content's required width
Adding min-w-0 and w-auto allows the SidebarInset again to shrink within the flex container instead of forcing a full-width layout → This makes the SidebarInset fit onto the page again and fixes the layout issues 
