### PR TITLE
Fix SearchBar Height in PromptTable Searchbar

### DIFF
--- a/prompt-ui-components/src/components/table/PromptTable/tableBarComponents/TableSearch.tsx
+++ b/prompt-ui-components/src/components/table/PromptTable/tableBarComponents/TableSearch.tsx
@@ -37,7 +37,7 @@ export function TableSearch({ value, onChange, table, filters }: TableSearchProp
 
   return (
     <div className='relative flex-1 min-w-0 h-full'>
-      <div className='flex rounded-md border border-input focus-within:ring-1 focus-within:ring-ring overflow-hidden h-full'>
+      <div className='flex rounded-md border border-input focus-within:ring-1 focus-within:ring-ring overflow-hidden h-10'>
         <div className='relative flex-1 min-w-0'>
           <Input
             placeholder='Search ... (press Enter)'


### PR DESCRIPTION
match the height of the Action Button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the table search bar's height to a fixed dimension for improved layout consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->