### PR TITLE
Table: Make filter dropdown scrollable

### DIFF
--- a/src/components/table/PromptTable/filters/TableFiltersMenu.tsx
+++ b/src/components/table/PromptTable/filters/TableFiltersMenu.tsx
@@ -24,7 +24,7 @@ export function TableFiltersMenu({ table, filters, trigger }: TableFiltersMenuPr
         )}
       </DropdownMenuTrigger>
 
-      <DropdownMenuContent className='w-64'>
+      <DropdownMenuContent className='w-64 max-h-[60vh] overflow-y-auto'>
         {filters.map((filter) => {
           const column = table.getColumn(filter.id)
           if (!column) return null


### PR DESCRIPTION
## What changed
Added `max-h-[60vh] overflow-y-auto` to the `DropdownMenuContent` in `TableFiltersMenu` and bumped version to `1.0.12`.

## Why
When a table has many filter sections (e.g. the Applications page with multiple additional score filters), the filter dropdown extends beyond the viewport without being scrollable. The `DropdownMenuContent` base class applies `overflow-hidden`; passing `overflow-y-auto` via `tailwind-merge` overrides the y-axis clipping so the dropdown becomes scrollable.

Fixes prompt-edu/prompt#1531

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Table filter dropdown menu now respects viewport height constraints and enables vertical scrolling when displaying many filter options, preventing the dropdown from expanding beyond visible screen boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->