### PR TITLE
Bump version to 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tumaet/prompt-ui-components",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/prompt-edu/prompt-lib.git"


### PR DESCRIPTION
## Summary
- Bumps `package.json` version from `1.1.1` to `1.1.2` to match the `v1.1.2` release tag
- Fixes the failed publish workflow: the `Validate release tag` step aborted because the tag `v1.1.2` didn't match the package version `v1.1.1`

## Test plan
- [ ] Merge and re-run (or re-trigger) the publish workflow for the `v1.1.2` release — the tag validation should now pass and the package should publish to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)