### PR TITLE
Fix npm publish auth for @tumaet scoped package

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,3 +3,4 @@ npmPublishAccess: 'public'
 npmScopes:
   tumaet:
     npmPublishRegistry: 'https://registry.npmjs.org'
+    npmAuthToken: '${NPM_AUTH_TOKEN}'


### PR DESCRIPTION
## Summary
- Adds `npmAuthToken` to the `@tumaet` scope in `.yarnrc.yml`
- Fixes the 404 error during `yarn npm publish`: yarn looks for the auth token in the scope config for scoped packages, not the global `npmAuthToken` set in the workflow

## Root cause
The workflow runs `yarn config set npmAuthToken $NPM_AUTH_TOKEN` (global), but when publishing `@tumaet/prompt-ui-components`, yarn resolves auth from `npmScopes.tumaet.npmAuthToken` — which was missing, causing an unauthenticated PUT → 404.

## Test plan
- [ ] Merge, move the `v1.1.2` tag to the new HEAD, and re-trigger the publish workflow — it should now authenticate and publish successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration for npm authentication settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->