### PR TITLE
Prompt Table: add button to select all rows matching current filter

### DIFF
--- a/src/components/table/PromptTable/columns/columnDefs/selectColumn.tsx
+++ b/src/components/table/PromptTable/columns/columnDefs/selectColumn.tsx
@@ -7,9 +7,13 @@ export const checkboxColumn = <T extends { id: string }>(): ColumnDef<T> => ({
   header: ({ table }) => (
     <div className='flex items-center justify-center'>
       <Checkbox
-        checked={table.getIsAllRowsSelected()}
+        checked={table.getSelectedRowModel().rows.length > 0}
         onCheckedChange={(checked) => {
-          table.toggleAllRowsSelected(!!checked)
+          if (checked) {
+            table.toggleAllPageRowsSelected(true)
+          } else {
+            table.resetRowSelection()
+          }
         }}
         onClick={(e) => e.stopPropagation()}
       />

--- a/src/components/table/PromptTable/tableBarComponents/TableInfoText.tsx
+++ b/src/components/table/PromptTable/tableBarComponents/TableInfoText.tsx
@@ -86,12 +86,7 @@ export function TableInfoText<TData>({
 
       {/* Right: [X selected ·] [Select all N ·] [N rows ·] columns dropdown */}
       <div className='flex items-center gap-1.5 shrink-0'>
-        {selectedCount > 0 && (
-          <>
-            <span className='text-foreground'>{selectedCount} selected</span>
-            <span>·</span>
-          </>
-        )}
+        {selectedCount > 0 && <span>{selectedCount} selected ·</span>}
         {canSelectAllFiltered && (
           <>
             <button

--- a/src/components/table/PromptTable/tableBarComponents/TableInfoText.tsx
+++ b/src/components/table/PromptTable/tableBarComponents/TableInfoText.tsx
@@ -22,8 +22,16 @@ export function TableInfoText<TData>({
 }: TableInfoTextProps<TData>): ReactElement {
   const { globalFilter, columnFilters } = table.getState()
   const selectedCount = table.getSelectedRowModel().rows.length
+  const filteredRows = table.getFilteredRowModel().rows
+  const canSelectAllFiltered = selectedCount > 0 && selectedCount < filteredRows.length
   const hideableColumns = table.getAllColumns().filter((col) => col.getCanHide())
   const visibleCount = hideableColumns.filter((col) => col.getIsVisible()).length
+
+  const selectAllFiltered = () => {
+    const next: Record<string, boolean> = {}
+    for (const row of filteredRows) next[row.id] = true
+    table.setRowSelection(next)
+  }
 
   const filterMetaById = Object.fromEntries(filters.map((f) => [f.id, f]))
 
@@ -76,7 +84,7 @@ export function TableInfoText<TData>({
         )}
       </div>
 
-      {/* Right: [X selected ·] X of Y rows · columns dropdown */}
+      {/* Right: [X selected ·] [Select all N ·] columns dropdown */}
       <div className='flex items-center gap-1.5 shrink-0'>
         {selectedCount > 0 && (
           <>
@@ -84,11 +92,18 @@ export function TableInfoText<TData>({
             <span>·</span>
           </>
         )}
-        <span>
-          {table.getFilteredRowModel().rows.length} of{' '}
-          {table.getPrePaginationRowModel().rows.length} rows
-        </span>
-        <span>·</span>
+        {canSelectAllFiltered && (
+          <>
+            <button
+              type='button'
+              onClick={selectAllFiltered}
+              className='font-medium text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300 transition-colors outline-none'
+            >
+              Select all {filteredRows.length}
+            </button>
+            <span>·</span>
+          </>
+        )}
         <DropdownMenu>
           <DropdownMenuTrigger className='flex items-center gap-1 hover:text-foreground transition-colors outline-none'>
             <Columns className='h-3.5 w-3.5' />

--- a/src/components/table/PromptTable/tableBarComponents/TableInfoText.tsx
+++ b/src/components/table/PromptTable/tableBarComponents/TableInfoText.tsx
@@ -84,7 +84,7 @@ export function TableInfoText<TData>({
         )}
       </div>
 
-      {/* Right: [X selected ·] [Select all N ·] columns dropdown */}
+      {/* Right: [X selected ·] [Select all N ·] [N rows ·] columns dropdown */}
       <div className='flex items-center gap-1.5 shrink-0'>
         {selectedCount > 0 && (
           <>
@@ -101,6 +101,14 @@ export function TableInfoText<TData>({
             >
               Select all {filteredRows.length}
             </button>
+            <span>·</span>
+          </>
+        )}
+        {selectedCount === 0 && (
+          <>
+            <span>
+              {filteredRows.length} row{filteredRows.length === 1 ? '' : 's'}
+            </span>
             <span>·</span>
           </>
         )}

--- a/src/components/table/PromptTable/tableBarComponents/TableInfoText.tsx
+++ b/src/components/table/PromptTable/tableBarComponents/TableInfoText.tsx
@@ -23,7 +23,9 @@ export function TableInfoText<TData>({
   const { globalFilter, columnFilters } = table.getState()
   const selectedCount = table.getSelectedRowModel().rows.length
   const filteredRows = table.getFilteredRowModel().rows
-  const canSelectAllFiltered = selectedCount > 0 && selectedCount < filteredRows.length
+  const filteredSelectedCount = table.getFilteredSelectedRowModel().rows.length
+  const canSelectAllFiltered =
+    filteredSelectedCount > 0 && filteredSelectedCount < filteredRows.length
   const hideableColumns = table.getAllColumns().filter((col) => col.getCanHide())
   const visibleCount = hideableColumns.filter((col) => col.getIsVisible()).length
 
@@ -99,7 +101,7 @@ export function TableInfoText<TData>({
             <span>·</span>
           </>
         )}
-        {selectedCount === 0 && (
+        {filteredSelectedCount === 0 && (
           <>
             <span>
               {filteredRows.length} row{filteredRows.length === 1 ? '' : 's'}


### PR DESCRIPTION
This PR adds a 'button' to prompt table that enables selecting all rows that match the current filter (including those not shown on the current page)

This is very useful for batch actions: Simply set the filters to what you need and select all matching the filter, then perform the action

To use it, select at least one row in the table, then click the 'Select all X rows' button in the header of the prompt table to select the rest. 

Demo:
If no rows are selected, simply the row count is shown
<img width="1366" height="740" alt="2026-06-24 at 11 21 32@2x" src="https://github.com/user-attachments/assets/95c23fc3-6b16-49b3-a8e0-f355c80932f0" />


If at least one row but not all (matchiing the current filter, like before) is selected, the amount of rows is previewed alongside a button to select all:
<img width="1398" height="1046" alt="2026-06-24 at 11 22 35@2x" src="https://github.com/user-attachments/assets/c9674b67-f563-46ad-9888-2cfcc69d2705" />

If all rows in the current filter are selected, only the rowcount is shown:
<img width="1390" height="958" alt="2026-06-24 at 11 22 42@2x" src="https://github.com/user-attachments/assets/df660199-d72e-4d04-a358-802d858b1a55" />

toggling the table checkbox when some are selected deselects all. 

I played around with different behaviours and i find this is the best. odoo (odoo.com) is a popular erp system that does it the same way

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Table header checkbox now selects/deselects only the rows on the current page.
  * Table info bar now shows “N selected” when any rows are selected.
  * Added a context-aware “Select all N” button to select all currently filtered rows (when some filtered rows are selected but not all).

* **UI Updates**
  * Updated the filtered-row selection text (removes the prior “X of Y rows” display) to reflect selection state within the current filter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->