### PR TITLE
Fix duplicate autolink plugin in MinimalTiptap editor

### DIFF
--- a/src/components/minimal-tiptap/hooks/use-minimal-tiptap.ts
+++ b/src/components/minimal-tiptap/hooks/use-minimal-tiptap.ts
@@ -36,6 +36,7 @@ export interface UseMinimalTiptapEditorProps extends UseEditorOptions {
 
 const createExtensions = (placeholder: string) => [
   StarterKit.configure({
+    link: false,
     horizontalRule: false,
     codeBlock: false,
     paragraph: { HTMLAttributes: { class: 'text-node' } },


### PR DESCRIPTION
## Summary

- Disable the `Link` extension bundled with `StarterKit` in `use-minimal-tiptap.ts` so the editor only registers the custom `Link` extension once.
- Resolves `RangeError: Adding different instances of a keyed plugin (autolink$1)` thrown when mounting the editor in consumer apps.

## Root cause

In Tiptap v3, `@tiptap/starter-kit` bundles `@tiptap/extension-link` by default. The minimal-tiptap hook configured `StarterKit` without disabling Link, then pushed a custom `Link` extension (extending `TiptapLink`) on top. Both registrations claimed the same keyed ProseMirror plugin (`autolink`), and the second registration threw during `EditorView` setup.

The fix passes `link: false` to `StarterKit.configure({...})`. The custom `Link` extension already inherits autolink, click-to-select-range, and paste-as-link behavior via `...(this.parent?.() || [])` inside `addProseMirrorPlugins`, so behavior is preserved.

## Test plan

- [x] `yarn build` succeeds, no TS errors; built `dist/components/minimal-tiptap/hooks/use-minimal-tiptap.js` contains `link: false` inside the `StarterKit.configure` call.
- [ ] Consumer smoke test (in a host app that uses `MinimalTiptapEditor` / `DescriptionMinimalTiptapEditor`):
  - [ ] Editor mounts without "Route loading failed" and without the `Adding different instances of a keyed plugin (autolink$1)` console error.
  - [ ] Typing a URL still creates an `<a>` tag (autolink works).
  - [ ] Selecting an existing link and applying / removing the link mark still works.
  - [ ] Saved HTML round-trips after reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled the link extension in the text editor to resolve configuration issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->