### PR TITLE
Persist participant table sort and filters in the URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tumaet/prompt-ui-components",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/prompt-edu/prompt-lib.git"

--- a/src/components/pages/CoursePhaseParticipationsTable/CoursePhaseParticipationsTable.tsx
+++ b/src/components/pages/CoursePhaseParticipationsTable/CoursePhaseParticipationsTable.tsx
@@ -7,7 +7,7 @@ import {
 import { getParticipantColumns } from './table/participationColumns'
 import { getParticipantFilters } from './table/participationFilters'
 import { ExportDeps, getParticipantActions } from './table/participationActions'
-import { PromptTable, RowAction, TableFilter } from '@/components'
+import { PromptTableURL, RowAction, TableFilter } from '@/components'
 import { CoursePhaseParticipationWithStudent } from '@tumaet/prompt-shared-state'
 import { useParticipantBatchActions } from './utils/updateBatch'
 
@@ -47,7 +47,7 @@ export const CoursePhaseParticipationsTable = ({
   )
 
   return (
-    <PromptTable<ParticipantRow>
+    <PromptTableURL<ParticipantRow>
       data={data}
       columns={columns}
       filters={filters}


### PR DESCRIPTION
## Summary
- Render the shared `CoursePhaseParticipationsTable` with `PromptTableURL` instead of `PromptTable`, so sorting, column filters, and global search are persisted to the URL query string and survive navigating into a participant detail view and back (browser back).
- Bump package version to `1.1.4`.

This brings the per-phase participants table in line with the core "Application" participants table, which already uses `PromptTableURL`.

## Behavior
- Persisted: sorting, all column filters (typed `select`/`numericRange` and custom JSON-serializable values), and global search.
- Not changed: column-visibility defaults and pagination (not synced to the URL).
- `PromptTableURL` writes via `window.history.replaceState`, so it is router-agnostic and adds no extra history entries.

## Release
After merge, publish a GitHub Release tagged `v1.1.4` to trigger the npm publish workflow. The consuming `prompt` repo will then bump its dependency from `1.1.3` to `1.1.4`.

## Test plan
- [x] `yarn lint` clean
- [x] `yarn build` green; compiled `dist` renders `PromptTableURL`
- [x] Packed a `1.1.4` tarball, installed into the `prompt` app, and `tsc --noEmit` passes for all 7 phase clients + core
- [x] Assessment remote dev server compiles against the new package
- [ ] Browser click-through on a phase participants table (sort/filter -> open participant -> back -> state restored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated a table view to use a URL-aware version, improving navigation and consistency when interacting with participation data.

* **Chores**
  * Bumped the app version from 1.1.3 to 1.1.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->