### PR TITLE
Fix date picker layout and month-navigation issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tumaet/prompt-ui-components",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/prompt-edu/prompt-lib.git"

--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -42,6 +42,7 @@ export const DatePicker = ({ date, onSelect }: DatePickerProps): React.JSX.Eleme
           onSelect={handleSelect}
           defaultMonth={date}
           initialFocus
+          fixedWeeks
           locale={enGB} // changes week start to monday
         />
       </PopoverContent>

--- a/src/components/DateRangePicker.tsx
+++ b/src/components/DateRangePicker.tsx
@@ -56,6 +56,7 @@ export const DatePickerWithRange: React.FC<DatePickerWithRangeProps> = ({
             selected={date}
             onSelect={setDate}
             numberOfMonths={numberOfMonths}
+            fixedWeeks
             locale={enGB}
           />
         </PopoverContent>

--- a/src/components/DateRangePicker.tsx
+++ b/src/components/DateRangePicker.tsx
@@ -12,12 +12,14 @@ import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover
 interface DatePickerWithRangeProps extends React.HTMLAttributes<HTMLDivElement> {
   date: DateRange | undefined
   setDate: (date: DateRange | undefined) => void
+  numberOfMonths?: number
 }
 
 export const DatePickerWithRange: React.FC<DatePickerWithRangeProps> = ({
   className,
   date,
   setDate,
+  numberOfMonths = 1,
   ...props
 }) => {
   return (
@@ -53,7 +55,7 @@ export const DatePickerWithRange: React.FC<DatePickerWithRangeProps> = ({
             defaultMonth={date?.from}
             selected={date}
             onSelect={setDate}
-            numberOfMonths={2}
+            numberOfMonths={numberOfMonths}
             locale={enGB}
           />
         </PopoverContent>


### PR DESCRIPTION
## What is the change?

Fixes several layout and navigation issues with the shared date pickers, reported downstream in [prompt#1042](https://github.com/prompt-edu/prompt/issues/1042) (the course copy dialog).

1. **`DatePickerWithRange` now renders a single month by default** (configurable via a new optional `numberOfMonths` prop). Two months are ~546px wide, which is wider than a `max-w-md` (448px) modal dialog — Radix then floats the popover detached above the dialog, overflowing both edges, with the prev/next chevrons pushed to the far corners over empty space. A single month keeps the calendar narrow enough to stay attached below the trigger and fit inside constrained containers.
2. **`fixedWeeks` on the range picker** — month grids vary between 5 and 6 rows, so the calendar height changed as you paged through months. Near the point where there's just enough room below the field, that height change made Radix recompute placement and **flip the popover between below and above the trigger while cycling months**. Rendering a fixed 6 weeks keeps the height constant, so it no longer flips.
3. **`fixedWeeks` on the single-date `DatePicker`** — same latent variable-height flip, fixed preemptively for consistency.

Version bumped to `1.1.4`.

## Reason for the change

See [prompt#1042](https://github.com/prompt-edu/prompt/issues/1042): users reported the copy dialog's date picker had "strange behavior when cycling through months" leading to miss-clicks that cancel the selection. Two distinct root causes:

- The two-month calendar overflowed the dialog, leaving tiny navigation controls flung to the far corners over areas outside the dialog — easy to miss-click and dismiss the popover.
- The per-month height change flipped the popover between below and above the trigger during navigation.

## How to Test

1. Render `<DatePickerWithRange>` inside a `max-w-md` dialog and open it — the calendar sits attached below the trigger and fits the dialog width.
2. Pick a start date, cycle through several months (including month transitions like Feb → Mar), pick an end date. The popover stays on one side the whole time and no longer flips; the navigation controls are compact and easy to hit.
3. Repeat with `<DatePicker>` (single date) — cycling months no longer flips the popover.
4. Pass `numberOfMonths={2}` to `DatePickerWithRange` to confirm the two-month layout is still available for wide contexts.

## Verification

Reproduced both issues and verified the fixes in an isolated harness rendering the real components inside a faithful copy of the dialog (Radix `Dialog` + `max-w-md` + form), driven headlessly:

- Two months → popover 546px wide, detached above the 448px dialog. Single month → 278px, attached below.
- Cycling months without `fixedWeeks`: `bottom(5wk) → top(6wk) → bottom(5wk) → …` (flips). With `fixedWeeks`: stays on one side at every viewport height.

## Notes

- The range picker default changes from two months to one, so existing consumers render a single month unless they opt into more via `numberOfMonths`.
- `fixedWeeks` makes short months show one extra row of muted trailing dates — standard, layout-stable calendar behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)