### PR TITLE
Add custom filename input to participations CSV export action

### DIFF
--- a/src/components/pages/CoursePhaseParticipationsTable/table/participationActions.tsx
+++ b/src/components/pages/CoursePhaseParticipationsTable/table/participationActions.tsx
@@ -1,6 +1,6 @@
 import { ExtraParticipantColumn, ParticipantRow } from './participationRow'
 import { CheckCircle, Download, XCircle } from 'lucide-react'
-import { downloadParticipations } from '../utils/downloadParticipations'
+import { DEFAULT_EXPORT_FILENAME, downloadParticipations } from '../utils/downloadParticipations'
 import { RowAction } from '@/components'
 
 export interface ExportDeps {
@@ -9,11 +9,9 @@ export interface ExportDeps {
   studentReadableDataKeys?: string[]
 }
 
-const DEFAULT_EXPORT_FILENAME = 'participation-export'
-
 function resolveCsvFilename(filename?: string): string {
-  const trimmed = filename?.trim() || DEFAULT_EXPORT_FILENAME
-  return trimmed.toLowerCase().endsWith('.csv') ? trimmed : `${trimmed}.csv`
+  const sanitized = (filename ?? '').replace(/[\\/:*?"<>|]/g, '').trim() || DEFAULT_EXPORT_FILENAME
+  return sanitized.toLowerCase().endsWith('.csv') ? sanitized : `${sanitized}.csv`
 }
 
 export function getParticipantActions(

--- a/src/components/pages/CoursePhaseParticipationsTable/table/participationActions.tsx
+++ b/src/components/pages/CoursePhaseParticipationsTable/table/participationActions.tsx
@@ -9,6 +9,13 @@ export interface ExportDeps {
   studentReadableDataKeys?: string[]
 }
 
+const DEFAULT_EXPORT_FILENAME = 'participation-export'
+
+function resolveCsvFilename(filename?: string): string {
+  const trimmed = filename?.trim() || DEFAULT_EXPORT_FILENAME
+  return trimmed.toLowerCase().endsWith('.csv') ? trimmed : `${trimmed}.csv`
+}
+
 export function getParticipantActions(
   actions: {
     setPassed: (rows: ParticipantRow[]) => void
@@ -44,7 +51,17 @@ export function getParticipantActions(
     {
       label: 'Export CSV',
       icon: <Download className='h-4 w-4' />,
-      onAction: (rows) => {
+      confirm: {
+        title: 'Export CSV',
+        description: (c) => `Export ${c} participants as CSV.`,
+        confirmLabel: 'Export',
+        input: {
+          label: 'Filename',
+          placeholder: DEFAULT_EXPORT_FILENAME,
+          defaultValue: DEFAULT_EXPORT_FILENAME,
+        },
+      },
+      onAction: (rows, filename) => {
         const originalRows = rows.map((r) => ({
           coursePhaseID: r.coursePhaseID,
           courseParticipationID: r.courseParticipationID,
@@ -61,6 +78,7 @@ export function getParticipantActions(
           exportDeps.restrictedDataKeys ?? [],
           exportDeps.studentReadableDataKeys ?? [],
           extraColumns,
+          resolveCsvFilename(filename),
         )
       },
     },

--- a/src/components/pages/CoursePhaseParticipationsTable/utils/downloadParticipations.ts
+++ b/src/components/pages/CoursePhaseParticipationsTable/utils/downloadParticipations.ts
@@ -2,13 +2,15 @@ import { CoursePhaseParticipationWithStudent } from '@tumaet/prompt-shared-state
 import { saveAs } from 'file-saver'
 import { ExtraParticipantColumn } from '../table/participationRow'
 
+export const DEFAULT_EXPORT_FILENAME = 'participation-export'
+
 export const downloadParticipations = (
   data: CoursePhaseParticipationWithStudent[],
   prevDataKeys: string[],
   restrictedDataKeys: string[],
   studentReadableDataKeys: string[],
   extraColumns: ExtraParticipantColumn<any>[] = [],
-  filename = 'participation-export.csv',
+  filename = `${DEFAULT_EXPORT_FILENAME}.csv`,
 ) => {
   if (!data || data.length === 0) {
     console.error('No data available to download.')

--- a/src/components/table/PromptTable/PromptTableTypes.ts
+++ b/src/components/table/PromptTable/PromptTableTypes.ts
@@ -27,12 +27,17 @@ export interface WithId {
 export interface RowAction<Type extends WithId> {
   label: string
   icon?: React.ReactNode
-  onAction: (rows: Type[]) => void | Promise<void>
+  onAction: (rows: Type[], inputValue?: string) => void | Promise<void>
   confirm?: {
     title?: string
     description: string | ((count: number) => string)
     confirmLabel?: string
     variant?: 'default' | 'destructive'
+    input?: {
+      label: string
+      placeholder?: string
+      defaultValue?: string
+    }
   }
   disabled?: (rows: Type[]) => boolean
   hide?: (rows: Type[]) => boolean

--- a/src/components/table/PromptTable/actions/ActionDialog.tsx
+++ b/src/components/table/PromptTable/actions/ActionDialog.tsx
@@ -6,14 +6,16 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
+  Input,
+  Label,
 } from '@/components/ui'
-import { ReactElement } from 'react'
+import { ReactElement, useState } from 'react'
 import { RowAction, WithId } from '../PromptTableTypes'
 
 interface ActionDialogProps<T extends WithId> {
   action: RowAction<T>
   selectedRows: T[]
-  onConfirm: () => Promise<void> | void
+  onConfirm: (inputValue?: string) => Promise<void> | void
   onClose: () => void
 }
 
@@ -23,6 +25,9 @@ export function ActionDialog<T extends WithId>({
   onClose,
   onConfirm,
 }: ActionDialogProps<T>): ReactElement {
+  const input = action.confirm?.input
+  const [inputValue, setInputValue] = useState(input?.defaultValue ?? '')
+
   const description =
     typeof action?.confirm?.description === 'function'
       ? action.confirm.description(selectedRows.length)
@@ -35,6 +40,18 @@ export function ActionDialog<T extends WithId>({
           <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
 
+        {input && (
+          <div className='grid gap-2'>
+            <Label htmlFor='action-dialog-input'>{input.label}</Label>
+            <Input
+              id='action-dialog-input'
+              value={inputValue}
+              placeholder={input.placeholder}
+              onChange={(event) => setInputValue(event.target.value)}
+            />
+          </div>
+        )}
+
         <DialogFooter>
           <Button variant='outline' onClick={onClose}>
             Cancel
@@ -42,7 +59,7 @@ export function ActionDialog<T extends WithId>({
           <Button
             variant={action.confirm?.variant ?? 'default'}
             onClick={async () => {
-              await onConfirm()
+              await onConfirm(input ? inputValue : undefined)
             }}
           >
             {action.confirm?.confirmLabel ?? 'Confirm'}

--- a/src/components/table/PromptTable/actions/ActionDialog.tsx
+++ b/src/components/table/PromptTable/actions/ActionDialog.tsx
@@ -40,31 +40,34 @@ export function ActionDialog<T extends WithId>({
           <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
 
-        {input && (
-          <div className='grid gap-2'>
-            <Label htmlFor='action-dialog-input'>{input.label}</Label>
-            <Input
-              id='action-dialog-input'
-              value={inputValue}
-              placeholder={input.placeholder}
-              onChange={(event) => setInputValue(event.target.value)}
-            />
-          </div>
-        )}
+        <form
+          className='space-y-4'
+          onSubmit={async (event) => {
+            event.preventDefault()
+            await onConfirm(input ? inputValue : undefined)
+          }}
+        >
+          {input && (
+            <div className='grid gap-2'>
+              <Label htmlFor='action-dialog-input'>{input.label}</Label>
+              <Input
+                id='action-dialog-input'
+                value={inputValue}
+                placeholder={input.placeholder}
+                onChange={(event) => setInputValue(event.target.value)}
+              />
+            </div>
+          )}
 
-        <DialogFooter>
-          <Button variant='outline' onClick={onClose}>
-            Cancel
-          </Button>
-          <Button
-            variant={action.confirm?.variant ?? 'default'}
-            onClick={async () => {
-              await onConfirm(input ? inputValue : undefined)
-            }}
-          >
-            {action.confirm?.confirmLabel ?? 'Confirm'}
-          </Button>
-        </DialogFooter>
+          <DialogFooter>
+            <Button type='button' variant='outline' onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type='submit' variant={action.confirm?.variant ?? 'default'}>
+              {action.confirm?.confirmLabel ?? 'Confirm'}
+            </Button>
+          </DialogFooter>
+        </form>
       </DialogContent>
     </Dialog>
   )

--- a/src/components/table/PromptTable/actions/ActionsMenu.tsx
+++ b/src/components/table/PromptTable/actions/ActionsMenu.tsx
@@ -32,11 +32,11 @@ export function ActionsMenu<Type extends WithId>({
     onFinish?.()
   }
 
-  const executeAction = async (action: RowAction<Type>) => {
+  const executeAction = async (action: RowAction<Type>, inputValue?: string) => {
     const rowsToAffect = [...selectedRows]
     try {
       setIsExecuting(true)
-      await action.onAction(rowsToAffect)
+      await action.onAction(rowsToAffect, inputValue)
     } finally {
       setIsExecuting(false)
       closeMenu()
@@ -52,12 +52,12 @@ export function ActionsMenu<Type extends WithId>({
     await executeAction(action)
   }
 
-  const clickDialogConfirm = async () => {
+  const clickDialogConfirm = async (inputValue?: string) => {
     if (!openActionConfirmation) return
 
     const action = openActionConfirmation
     setOpenActionConfirmation(null)
-    await executeAction(action)
+    await executeAction(action, inputValue)
   }
 
   return (


### PR DESCRIPTION
## Motivation

Closes prompt-edu/prompt#689

The "Export CSV" action in the `CoursePhaseParticipationsTable` downloaded the file immediately with a hardcoded `participation-export.csv` name. Users had no way to give the export a meaningful filename.

## Changes

- Extend the generic `RowAction.confirm` config with an optional `input` field (`label`, `placeholder`, `defaultValue`) and pass the entered value to `onAction` as an optional second parameter — fully backwards compatible for existing actions.
- `ActionDialog` renders a labeled text input when the action's confirm config defines one.
- The participations "Export CSV" action now opens a confirm dialog with a filename input, pre-filled with `participation-export`. A `.csv` extension is appended if missing, and blank input falls back to the default name.

## Verification

- `yarn lint` and `yarn build:esm` pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for entering a custom filename when exporting CSVs.
  * Confirmation dialogs can now include an optional text field for user input.

* **Bug Fixes**
  * Improved CSV export filename handling by trimming spaces, adding the `.csv` extension when needed, and using a default name when the field is left blank.
  * Export actions now correctly use the entered value during confirmation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->