### PR TITLE
Dependencies: tune Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,21 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "semanticCommits": "disabled",
+  "commitMessagePrefix": "Dependencies:",
   "prConcurrentLimit": 3,
-  "rangeStrategy": "bump"
+  "rangeStrategy": "bump",
+  "minimumReleaseAge": "7 days",
+  "packageRules": [
+    {
+      "description": "Group all non-major updates together",
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "all non-major dependencies"
+    },
+    {
+      "description": "No minimum age for security updates",
+      "matchCategories": ["security"],
+      "minimumReleaseAge": "0 days"
+    }
+  ]
 }


### PR DESCRIPTION
Aligns this repo's Renovate config with the tuned config in `tease`:\n\n- Disable semantic commits; prefix commits with `Dependencies:`\n- Cap concurrent PRs at 3\n- `rangeStrategy: bump`\n- Require a 7-day minimum release age (0 days for security updates)\n- Group all non-major (minor + patch) updates into a single PR